### PR TITLE
Recommend adding timeout example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To install this module, run the following commands:
         password => 'tiger',
         database => 'test',
         # ssl => 1, # enable SSL/TLS access
+        # timeout => 5, # set timeout to 5 seconds
     );
     
     $ix->write_points(


### PR DESCRIPTION
Timeouts are important; the default of 120 seconds will cause most requests to fail.