### PR TITLE
write_points POD: graphables must be numbers

### DIFF
--- a/lib/InfluxDB.pm
+++ b/lib/InfluxDB.pm
@@ -667,6 +667,9 @@ HashRef like following:
         ],
     }
 
+The C<time> and any other data fields which should be graphable must
+be numbers, not text.  See L<JSON/simple scalars>.
+
 =item time_precision => "s" | "m" | "u" (optional)
 
 The precision timestamps should come back in. Valid options are s for seconds, m for milliseconds, and u for microseconds.


### PR DESCRIPTION
I added a comment to `write_points`, which would have saved me some head-scratching.

Thanks for the API, very handy.