### PR TITLE
Provide support for disabled HTTP authentication 

### DIFF
--- a/lib/InfluxDB.pm
+++ b/lib/InfluxDB.pm
@@ -30,8 +30,8 @@ sub new {
     state $rule = Data::Validator->new(
         host     => { isa => 'Str' },
         port     => { isa => 'Int', default => 8086 },
-        username => { isa => 'Str' },
-        password => { isa => 'Str' },
+        username => { isa => 'Str', optional => 1 },
+        password => { isa => 'Str', optional => 1 },
         database => { isa => 'Str' },
         ssl      => { isa => 'Bool', default => 0 },
 
@@ -496,10 +496,11 @@ sub _build_url {
     )->with('Method');
     my($self, $args) = $rule->validate(@_);
 
-    my $url = sprintf("%s://%s:%s@%s:%d%s",
+    my $url = sprintf("%s://%s%s:%d%s",
                       ($self->ssl ? 'https' : 'http'),
-                      $self->username,
-                      $self->{password},
+                      ($self->username and $self->{password})
+                          ? sprintf("%s\@%s:", $self->username, $self->{password})
+                          : '',
                       $self->host,
                       $self->port,
                       $args->{path},

--- a/t/disabled-http-authentication.t
+++ b/t/disabled-http-authentication.t
@@ -1,0 +1,37 @@
+use strict;
+use Test::More;
+
+require InfluxDB;
+InfluxDB->import;
+note("disabled-http-authentication");
+my $obj = new_ok("InfluxDB" => [
+    host => '127.0.0.1',
+    database => 'dummy',
+]);
+
+{
+    my $obj = InfluxDB->new(
+        username => 'user',
+        password => 'pwd',
+        database => 'dummy',
+        host     => 'a.dummy.influxdb.host',
+        port     => 8086,
+    );
+    my $url = $obj->_build_url(path => '');
+
+    is($url, 'http://user@pwd:a.dummy.influxdb.host:8086', 'URL correctly formatted when user & pwd are set');
+};
+
+{
+   my $obj = InfluxDB->new(
+        database => 'dummy',
+        host     => 'a.dummy.influxdb.host',
+        port     => 8086,
+    );
+    my $url = $obj->_build_url(path => '');
+
+    is($url, 'http://a.dummy.influxdb.host:8086', 'URL correctly formatted when user & pwd are NOT set');
+};
+
+
+done_testing;


### PR DESCRIPTION
Set both 'username' and 'password' attributes to be optional.
At the '_build_url' method, took into account the case of 'username'
and 'password' not being set.